### PR TITLE
disable gamepad interposer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ LABEL maintainer="aptalca"
 
 ENV \
   HOME="/config" \
-  TITLE="Shotcut"
+  TITLE="Shotcut" \
+  NO_GAMEPAD="true"
 
 RUN \
   echo "**** add icon ****" && \

--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **05.02.26:** - Disable gamepad interposer.
 * **28.12.25:** - Add Wayland init logic.
 * **22.09.25:** - Rebase to Debian Trixie.
 * **12.07.25:** - Rebase to Selkies, HTTPS IS NOW REQUIRED.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -119,6 +119,7 @@ init_diagram: |
   "shotcut:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "05.02.26:", desc: "Disable gamepad interposer."}
   - {date: "28.12.25:", desc: "Add Wayland init logic."}
   - {date: "22.09.25:", desc: "Rebase to Debian Trixie."}
   - {date: "12.07.25:", desc: "Rebase to Selkies, HTTPS IS NOW REQUIRED."}


### PR DESCRIPTION
They must be using udev calls we intercept with the gamepad interposer. This fixes not being able to encode videos in recent versions. 